### PR TITLE
use Procfile to $PORT from Heroku to NextJS

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: yarn start -p $PORT


### PR DESCRIPTION
Next is a little weird in that it's the first app framework I've seen that
_doesn't support a `$PORT`_ environment variable right out of the box.
