### PR TITLE
Added Typescript with optional strict checking 

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: yarn start -p $PORT


### PR DESCRIPTION
- unstrict checking of Typscript turned on
- begin notes on TS
- add script to opt in to strict type checking
  - `yarn run watch:types:strict` starts up the typscript checker with strict
      rules enabled and updates on file changes
  - `yarn run types:strict` is for the ci to run if PR targets the typescript
      branch

There are some disadvantages to this, mainly that if no one writes any types or
uses the types that have already been written, it's gonna be a bad day for
whoever opts in to strict type checking because they will be forced to write
types for all the bits of code that have been comitted since someone last did a
PR through this part of the pipeline

